### PR TITLE
Fix for previous flambda2 keepalive fix

### DIFF
--- a/src/wrapper/wrapper.ml
+++ b/src/wrapper/wrapper.ml
@@ -775,6 +775,8 @@ module Column = struct
         if Valid.get valid i then Some ba.{i} else None)
 end
 
+let keep_alive = ref []
+
 module Writer = struct
   let verbose = false
 
@@ -787,23 +789,19 @@ module Writer = struct
   (* Since [release_schema] and [release_array] are morally globals, we don't ever intend
      to free them. However, flambda2 optimizes them into locals, so they're liable to get
      collected, at which point the finalizer in [Foreign] complains that we never called
-     [Foreign.Funptr.free]. So we need to suppress that error by freeing the pointer
-     first. *)
-  let free_global_ptr_on_finalise ptr ~free =
-    Caml.Gc.finalise (fun ptr -> free ptr) ptr;
-    ptr
+     [Foreign.Funptr.free]. To avoid this we explicitly keep these values alive. *)
 
   (* For now [release_schema] and [release_array] don't do anything as the
      memory is entirely managed on the ocaml side. *)
   let release_schema =
     let release_schema _ = if verbose then Stdio.printf "release schema\n%!" in
     Release_schema_fn_ptr.of_fun release_schema
-    |> free_global_ptr_on_finalise ~free:Release_schema_fn_ptr.free
 
   let release_array =
     let release_array _ = if verbose then Stdio.printf "release array\n%!" in
     Release_array_fn_ptr.of_fun release_array
-    |> free_global_ptr_on_finalise ~free:Release_array_fn_ptr.free
+
+  let () = keep_alive := [Obj.repr release_schema; Obj.repr release_array]
 
   let release_array_ptr = Ctypes.(coerce Release_array_fn_ptr.t (ptr void) release_array)
 

--- a/src/wrapper/wrapper.mli
+++ b/src/wrapper/wrapper.mli
@@ -268,3 +268,6 @@ module Builder : sig
 
   val make_table : (string * t) list -> Table.t
 end
+
+(* See comment in wrapper.ml about Flambda 2. *)
+val keep_alive : Obj.t list ref


### PR DESCRIPTION
The previous fix for flambda2, related to values whose lifetimes are shorter in flambda2 than with other variants of the compiler, was incorrect (I think it caused a double free or similar).  This PR contains a way of keeping the relevant values alive permanently without affecting any other semantics.